### PR TITLE
feat: Make Prometheus gRPC histogram buckets configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	DisablePormetheus bool `envconfig:"DISABLE_PROMETHEUS" default:"false"`
 	// Enables grpc request histograms in prometheus reporting
 	EnablePrometheusGRPCHistogram bool `envconfig:"ENABLE_PROMETHEUS_GRPC_HISTOGRAM" default:"true"`
+	// PrometheusGRPCHistogramBuckets specifies custom histogram buckets for gRPC request latency metrics
+	// Format: comma-separated float values in seconds (e.g., "0.005,0.01,0.025,0.05,0.1,0.25,0.5,1,2.5,5,10")
+	// If empty, uses the default buckets from go-grpc-prometheus
+	PrometheusGRPCHistogramBuckets []float64 `envconfig:"PROMETHEUS_GRPC_HISTOGRAM_BUCKETS" default:""`
 	// The License key for NewRelic metrics reporting
 	NewRelicLicenseKey string `envconfig:"NEW_RELIC_LICENSE_KEY" default:""`
 	// When set to true, disables all NewRelic reporting

--- a/core.go
+++ b/core.go
@@ -117,7 +117,11 @@ func (c *cb) processConfig() {
 		startSignalHandler(c, dur)
 	}
 	if c.config.EnablePrometheusGRPCHistogram {
-		grpc_prometheus.EnableHandlingTimeHistogram()
+		if len(c.config.PrometheusGRPCHistogramBuckets) > 0 {
+			grpc_prometheus.EnableHandlingTimeHistogram(grpc_prometheus.WithHistogramBuckets(c.config.PrometheusGRPCHistogramBuckets))
+		} else {
+			grpc_prometheus.EnableHandlingTimeHistogram()
+		}
 	}
 
 	// Setup OpenTelemetry - custom OTLP takes precedence over New Relic


### PR DESCRIPTION
Add support for custom histogram buckets for gRPC request latency metrics via PROMETHEUS_GRPC_HISTOGRAM_BUCKETS environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing Prometheus gRPC histogram buckets to provide fine-tuned observability metrics collection. Users can now specify custom bucket threshold values (comma-separated seconds) via a new environment variable. When this variable is not configured, the system automatically applies sensible default histogram buckets for standard usage scenarios and typical workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->