### PR TITLE
docs: regenerate README from updated source

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The core module is the base module for cold brew and provides the base implement
 
 
 <a name="ConfigureInterceptors"></a>
-## func [ConfigureInterceptors](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L306>)
+## func [ConfigureInterceptors](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L325>)
 
 ```go
 func ConfigureInterceptors(DoNotLogGRPCReflection bool, traceHeaderName string)
@@ -69,7 +69,7 @@ func ConfigureInterceptors(DoNotLogGRPCReflection bool, traceHeaderName string)
 ConfigureInterceptors configures the interceptors package with the provided DoNotLogGRPCReflection is a boolean that indicates whether to log the grpc.reflection.v1alpha.ServerReflection service calls in logs traceHeaderName is the name of the header to use for tracing \(e.g. X\-Trace\-Id\) \- if empty, defaults to X\-Trace\-Id
 
 <a name="InitializeVTProto"></a>
-## func [InitializeVTProto](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L351>)
+## func [InitializeVTProto](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L373>)
 
 ```go
 func InitializeVTProto()
@@ -80,7 +80,7 @@ InitializeVTProto initializes the vtproto package for use with the service
 https://github.com/planetscale/vtprotobuf?tab=readme-ov-file#mixing-protobuf-implementations-with-grpc
 
 <a name="SetupAutoMaxProcs"></a>
-## func [SetupAutoMaxProcs](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L317>)
+## func [SetupAutoMaxProcs](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L339>)
 
 ```go
 func SetupAutoMaxProcs()
@@ -89,7 +89,7 @@ func SetupAutoMaxProcs()
 SetupAutoMaxProcs sets up the GOMAXPROCS to match Linux container CPU quota This is used to set the GOMAXPROCS to the number of CPUs allocated to the container
 
 <a name="SetupEnvironment"></a>
-## func [SetupEnvironment](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L94>)
+## func [SetupEnvironment](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L96>)
 
 ```go
 func SetupEnvironment(env string)
@@ -98,7 +98,7 @@ func SetupEnvironment(env string)
 SetupEnvironment sets the environment This is used to identify the environment in Sentry and New Relic env is the environment to set for the service \(e.g. prod, staging, dev\)
 
 <a name="SetupHystrixPrometheus"></a>
-## func [SetupHystrixPrometheus](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L298>)
+## func [SetupHystrixPrometheus](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L317>)
 
 ```go
 func SetupHystrixPrometheus()
@@ -107,7 +107,7 @@ func SetupHystrixPrometheus()
 SetupHystrixPrometheus sets up the hystrix metrics This is a workaround for hystrix\-go not supporting the prometheus registry
 
 <a name="SetupLogger"></a>
-## func [SetupLogger](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L70>)
+## func [SetupLogger](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L72>)
 
 ```go
 func SetupLogger(logLevel string, jsonlogs bool) error
@@ -116,7 +116,7 @@ func SetupLogger(logLevel string, jsonlogs bool) error
 SetupLogger sets up the logger It uses the coldbrew logger to log messages to stdout logLevel is the log level to set for the logger jsonlogs is a boolean to enable or disable json logs
 
 <a name="SetupNROpenTelemetry"></a>
-## func [SetupNROpenTelemetry](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L282>)
+## func [SetupNROpenTelemetry](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L297>)
 
 ```go
 func SetupNROpenTelemetry(serviceName, license, version string, ratio float64) error
@@ -134,7 +134,7 @@ Parameters:
 - ratio: the sampling ratio to use for traces \(0.0 to 1.0\)
 
 <a name="SetupNewRelic"></a>
-## func [SetupNewRelic](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L45>)
+## func [SetupNewRelic](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L46>)
 
 ```go
 func SetupNewRelic(serviceName, apiKey string, tracing bool) error
@@ -143,7 +143,7 @@ func SetupNewRelic(serviceName, apiKey string, tracing bool) error
 SetupNewRelic sets up the New Relic tracing and monitoring agent for the service It uses the New Relic Go Agent to send traces to New Relic One APM and Insights serviceName is the name of the service apiKey is the New Relic license key tracing is a boolean to enable or disable tracing
 
 <a name="SetupOpenTelemetry"></a>
-## func [SetupOpenTelemetry](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L200>)
+## func [SetupOpenTelemetry](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L206>)
 
 ```go
 func SetupOpenTelemetry(config OTLPConfig) error
@@ -181,7 +181,7 @@ err := SetupOpenTelemetry(config)
 ```
 
 <a name="SetupReleaseName"></a>
-## func [SetupReleaseName](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L103>)
+## func [SetupReleaseName](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L105>)
 
 ```go
 func SetupReleaseName(rel string)
@@ -190,7 +190,7 @@ func SetupReleaseName(rel string)
 SetupReleaseName sets the release name This is used to identify the release in Sentry rel is the release name to set for the service \(e.g. v1.0.0\)
 
 <a name="SetupSentry"></a>
-## func [SetupSentry](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L85>)
+## func [SetupSentry](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L87>)
 
 ```go
 func SetupSentry(dsn string)
@@ -220,7 +220,7 @@ type CB interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/go-coldbrew/core/blob/main/core.go#L502>)
+### func [New](<https://github.com/go-coldbrew/core/blob/main/core.go#L526>)
 
 ```go
 func New(c config.Config) CB
@@ -273,7 +273,7 @@ type CBStopper interface {
 ```
 
 <a name="OTLPConfig"></a>
-## type [OTLPConfig](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L138-L170>)
+## type [OTLPConfig](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L144-L176>)
 
 OTLPConfig holds configuration for OpenTelemetry OTLP exporter
 

--- a/config/README.md
+++ b/config/README.md
@@ -16,7 +16,7 @@ import "github.com/go-coldbrew/core/config"
 
 
 <a name="Config"></a>
-## type [Config](<https://github.com/go-coldbrew/core/blob/main/config/config.go#L6-L129>)
+## type [Config](<https://github.com/go-coldbrew/core/blob/main/config/config.go#L6-L137>)
 
 Config is the configuration for the Coldbrew server It is populated from environment variables and has sensible defaults for all fields so that you can just use it as is without any configuration The following environment variables are supported and can be used to override the defaults for the fields
 
@@ -42,12 +42,20 @@ type Config struct {
     SwaggerURL string `envconfig:"SWAGGER_URL" default:"/swagger/"`
     // Should we disable go debug at /debug/, defaults to false
     DisableDebug bool `envconfig:"DISABLE_DEBUG" default:"false"`
-    // Should we disable prometheus at /metrics, defaults to false
+    // DisablePrometheus controls whether prometheus metrics are disabled at /metrics, defaults to false
+    DisablePrometheus bool `envconfig:"DISABLE_PROMETHEUS" default:"false"`
+    // Deprecated: Use DisablePrometheus instead.
     DisablePormetheus bool `envconfig:"DISABLE_PROMETHEUS" default:"false"`
     // Enables grpc request histograms in prometheus reporting
     EnablePrometheusGRPCHistogram bool `envconfig:"ENABLE_PROMETHEUS_GRPC_HISTOGRAM" default:"true"`
+    // PrometheusGRPCHistogramBuckets specifies custom histogram buckets for gRPC request latency metrics
+    // Format: comma-separated float values in seconds (e.g., "0.005,0.01,0.025,0.05,0.1,0.25,0.5,1,2.5,5,10")
+    // If empty, uses the default buckets from go-grpc-prometheus
+    PrometheusGRPCHistogramBuckets []float64 `envconfig:"PROMETHEUS_GRPC_HISTOGRAM_BUCKETS" default:""`
     // The License key for NewRelic metrics reporting
     NewRelicLicenseKey string `envconfig:"NEW_RELIC_LICENSE_KEY" default:""`
+    // When set to true, disables all NewRelic reporting
+    DisableNewRelic bool `envconfig:"DISABLE_NEW_RELIC" default:"false"`
     // Enable NewRelic Distributed Tracing
     NewRelicDistributedTracing bool `envconfig:"NEW_RELIC_DISTRIBUTED_TRACING" default:"true"`
     // Enable new relic opentelemetry


### PR DESCRIPTION
## Summary
- Regenerate auto-generated README via gomarkdoc to reflect recent code changes

## Test plan
- [x] README reflects current API