### PR TITLE
feat: replace go-grpc-prometheus and gziphandler

### DIFF
--- a/core.go
+++ b/core.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-coldbrew/log/loggers"
 	"github.com/go-coldbrew/options"
 	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/klauspost/compress/gzhttp"
 	"github.com/opentracing/opentracing-go"
@@ -119,11 +118,7 @@ func (c *cb) processConfig() {
 		startSignalHandler(c, dur)
 	}
 	if c.config.EnablePrometheusGRPCHistogram {
-		if len(c.config.PrometheusGRPCHistogramBuckets) > 0 {
-			grpc_prometheus.EnableHandlingTimeHistogram(grpc_prometheus.WithHistogramBuckets(c.config.PrometheusGRPCHistogramBuckets))
-		} else {
-			grpc_prometheus.EnableHandlingTimeHistogram()
-		}
+		interceptors.EnablePrometheusHandlingTimeHistogram(c.config.PrometheusGRPCHistogramBuckets)
 	}
 
 	// Setup OpenTelemetry - custom OTLP takes precedence over New Relic

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/go-coldbrew/tracing v0.0.7
 	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/jaegertracing/jaeger-lib v2.4.1+incompatible
 	github.com/klauspost/compress v1.18.5
@@ -144,6 +143,8 @@ require (
 	github.com/gostaticanalysis/comment v1.5.0 // indirect
 	github.com/gostaticanalysis/forcetypeassert v0.2.0 // indirect
 	github.com/gostaticanalysis/nilerr v0.1.2 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,6 @@ github.com/go-coldbrew/errors v0.2.2 h1:yHQ5jNiWRRuP++LJSpJK3PfPQchC9ejPTdVhmMlq
 github.com/go-coldbrew/errors v0.2.2/go.mod h1:nlRAJImqLRUNrZ3bnFRnlLix6NFGnK5IgWA30LwLdQk=
 github.com/go-coldbrew/hystrixprometheus v0.1.2 h1:WSt4FtYr8xNDKgdGWYpMfXGFIK7zdDSBwDSbpuPhBHI=
 github.com/go-coldbrew/hystrixprometheus v0.1.2/go.mod h1:OrNRHHxZagpmQXNp//oHKOemGSU0ScOqEcJgeKbJ+wg=
-github.com/go-coldbrew/interceptors v0.1.11 h1:xTgRjqzex6ojHelIthu/fJGDeo/AaNN+k4ZOWR22/hU=
-github.com/go-coldbrew/interceptors v0.1.11/go.mod h1:1rV2lIimdoyBJ+KViSt5POMHIs44N84Tk3BuzKi+El4=
 github.com/go-coldbrew/log v0.2.6 h1:DZHQlPRRpMM3qUVcLJMUv9Vh3rcl5KlFPuVBFioX4SY=
 github.com/go-coldbrew/log v0.2.6/go.mod h1:EAQFVdPADXsJk8CuFEdJWutMUcJRq9jsDFW2FaqdvhU=
 github.com/go-coldbrew/options v0.2.5 h1:InmjsOBPrk9FGjGUruuNqdRsaX9ZCynCg6+WmRCkHmQ=
@@ -315,8 +313,10 @@ github.com/gostaticanalysis/testutil v0.5.0 h1:Dq4wT1DdTwTGCQQv3rl3IvD5Ld0E6HiY+
 github.com/gostaticanalysis/testutil v0.5.0/go.mod h1:OLQSbuM6zw2EvCcXTz1lVq5unyoNft372msDY0nY5Hs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
-github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
-github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajRPKYMrB7E0MbtzWVi1K4ns=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3/go.mod h1:NbCUVmiS4foBGBHOYlCT25+YmGpJ32dZPi75pGEUpj4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0 h1:CUW5RYIcysz+D3B+l1mDeXrQ7fUvGGCwJfdASSzbrfo=


### PR DESCRIPTION
## Summary
- Remove `go-grpc-prometheus` (archived) — histogram configuration now via `interceptors.EnablePrometheusHandlingTimeHistogram()`
- Replace `NYTimes/gziphandler` (unmaintained since 2019) with `klauspost/compress/gzhttp` for ~30% better compression performance

**Depends on:** go-coldbrew/interceptors PR #21 being merged and tagged first. After that, run `go get github.com/go-coldbrew/interceptors@<new-tag> && go mod tidy` before this PR can build.

## Test plan
- [x] `make build` passes (with local replace directive for interceptors)
- [x] `make test` passes (`go test -race ./...`)
- [x] `make lint` passes (golangci-lint 0 issues + govulncheck 0 vulnerabilities)
- [ ] Update interceptors dependency version after interceptors PR is merged and tagged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependencies: replaced a legacy gRPC Prometheus package with newer gRPC middleware Prometheus providers.

* **Refactor**
  * Simplified and modernized gRPC metrics handling so histogram collection uses the updated middleware consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->