### PR TITLE
fix: add otelgrpc stats handlers for gRPC server/client tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ For full documentation, visit https://docs.coldbrew.cloud
 - [Constants](<#constants>)
 - [func ConfigureInterceptors\(DoNotLogGRPCReflection bool, traceHeaderName string\)](<#ConfigureInterceptors>)
 - [func InitializeVTProto\(\)](<#InitializeVTProto>)
+- [func SetOTELGRPCClientOptions\(opts ...otelgrpc.Option\)](<#SetOTELGRPCClientOptions>)
+- [func SetOTELGRPCServerOptions\(opts ...otelgrpc.Option\)](<#SetOTELGRPCServerOptions>)
 - [func SetupAutoMaxProcs\(\)](<#SetupAutoMaxProcs>)
 - [func SetupEnvironment\(env string\)](<#SetupEnvironment>)
 - [func SetupHystrixPrometheus\(\)](<#SetupHystrixPrometheus>)
@@ -130,6 +132,24 @@ func InitializeVTProto()
 InitializeVTProto initializes the vtproto package for use with the service
 
 https://github.com/planetscale/vtprotobuf?tab=readme-ov-file#mixing-protobuf-implementations-with-grpc
+
+<a name="SetOTELGRPCClientOptions"></a>
+## func [SetOTELGRPCClientOptions](<https://github.com/go-coldbrew/core/blob/main/core.go#L348>)
+
+```go
+func SetOTELGRPCClientOptions(opts ...otelgrpc.Option)
+```
+
+SetOTELGRPCClientOptions sets options for the OTEL gRPC client stats handler. Must be called during init, before the gRPC client is created.
+
+<a name="SetOTELGRPCServerOptions"></a>
+## func [SetOTELGRPCServerOptions](<https://github.com/go-coldbrew/core/blob/main/core.go#L342>)
+
+```go
+func SetOTELGRPCServerOptions(opts ...otelgrpc.Option)
+```
+
+SetOTELGRPCServerOptions sets options for the OTEL gRPC server stats handler. Must be called during init, before the gRPC server starts. Example: core.SetOTELGRPCServerOptions\(otelgrpc.WithFilter\(...\)\)
 
 <a name="SetupAutoMaxProcs"></a>
 ## func [SetupAutoMaxProcs](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L314>)
@@ -272,7 +292,7 @@ type CB interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/go-coldbrew/core/blob/main/core.go#L540>)
+### func [New](<https://github.com/go-coldbrew/core/blob/main/core.go#L571>)
 
 ```go
 func New(c config.Config) CB

--- a/core.go
+++ b/core.go
@@ -22,12 +22,14 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/klauspost/compress/gzhttp"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/credentials/insecure"
 	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
@@ -255,6 +257,7 @@ func (c *cb) initHTTP(ctx context.Context) (*http.Server, error) {
 
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler(otelGRPCClientOpts...)),
 		grpc.WithUnaryInterceptor(
 			interceptors.DefaultClientInterceptor(
 				interceptors.WithoutHystrix(),
@@ -319,9 +322,37 @@ func (c *cb) runHTTP(_ context.Context, svr *http.Server) error {
 	return svr.ListenAndServe()
 }
 
+// otelgrpc options configured during init via SetOTELGRPCServerOptions/SetOTELGRPCClientOptions.
+// Defaults filter out health/ready/reflection RPCs to reduce noise.
+var otelGRPCServerOpts = []otelgrpc.Option{
+	otelgrpc.WithFilter(defaultOTELFilter),
+}
+var otelGRPCClientOpts []otelgrpc.Option
+
+// defaultOTELFilter excludes health checks, readiness probes, and gRPC
+// reflection from tracing to reduce noise — matching the previous
+// grpc_opentracing filter behavior.
+func defaultOTELFilter(info *stats.RPCTagInfo) bool {
+	return interceptors.FilterMethodsFunc(context.Background(), info.FullMethodName)
+}
+
+// SetOTELGRPCServerOptions sets options for the OTEL gRPC server stats handler.
+// Must be called during init, before the gRPC server starts.
+// Example: core.SetOTELGRPCServerOptions(otelgrpc.WithFilter(...))
+func SetOTELGRPCServerOptions(opts ...otelgrpc.Option) {
+	otelGRPCServerOpts = opts
+}
+
+// SetOTELGRPCClientOptions sets options for the OTEL gRPC client stats handler.
+// Must be called during init, before the gRPC client is created.
+func SetOTELGRPCClientOptions(opts ...otelgrpc.Option) {
+	otelGRPCClientOpts = opts
+}
+
 func (c *cb) getGRPCServerOptions() []grpc.ServerOption {
 	so := make([]grpc.ServerOption, 0)
 	so = append(so,
+		grpc.StatsHandler(otelgrpc.NewServerHandler(otelGRPCServerOpts...)),
 		grpc.ChainUnaryInterceptor(interceptors.DefaultInterceptors()...),
 		grpc.ChainStreamInterceptor(interceptors.DefaultStreamInterceptors()...),
 	)

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/newrelic/go-agent/v3 v3.42.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.23.2
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/bridge/opentracing v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -630,6 +630,8 @@ go.augendre.info/fatcontext v0.9.0 h1:Gt5jGD4Zcj8CDMVzjOJITlSb9cEch54hjRRlN3qDoj
 go.augendre.info/fatcontext v0.9.0/go.mod h1:L94brOAT1OOUNue6ph/2HnwxoNlds9aXDF2FcUntbNw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 h1:yI1/OhfEPy7J9eoa6Sj051C7n5dvpj0QX8g4sRchg04=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0/go.mod h1:NoUCKYWK+3ecatC4HjkRktREheMeEtrXoQxrqYFeHSc=
 go.opentelemetry.io/otel v1.42.0 h1:lSQGzTgVR3+sgJDAU/7/ZMjN9Z+vUip7leaqBKy4sho=
 go.opentelemetry.io/otel v1.42.0/go.mod h1:lJNsdRMxCUIWuMlVJWzecSMuNjE7dOYyWlqOXWkdqCc=
 go.opentelemetry.io/otel/bridge/opentracing v1.42.0 h1:gR6G6tW10WBrzfDJxTn30zhjO5jVCPAxYhUfWoYDnAY=


### PR DESCRIPTION
## Summary

Fixes a regression from the OTEL migration (#51) where `grpc_opentracing` interceptors were removed but the replacement `otelgrpc` stats handlers were never wired in, causing gRPC root spans (e.g., `/pkg.Service/Method`) to stop appearing in tracing backends.

### Changes
- Add `otelgrpc.NewServerHandler()` to gRPC server options — creates server spans for incoming RPCs
- Add `otelgrpc.NewClientHandler()` to gRPC gateway client options — creates client spans for outbound RPCs
- Default server filter excludes health/ready/reflection RPCs (matches previous `grpc_opentracing` behavior)
- Add `SetOTELGRPCServerOptions()`/`SetOTELGRPCClientOptions()` for init-time customization

### Customization

```go
import "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"

func init() {
    core.SetOTELGRPCServerOptions(
        otelgrpc.WithFilter(myCustomFilter),
        otelgrpc.WithTracerProvider(myProvider),
    )
}
```

## Test plan
- [x] `go test -race ./...` — passes
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- OpenTelemetry gRPC instrumentation is now integrated into the core
- New configuration functions enable customization of gRPC client and server options at initialization time

**Documentation**
- Updated API reference documentation with new configuration function details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->