### PR TITLE
fix: use runtime.HTTPPattern for route extraction in spans

### DIFF
--- a/core.go
+++ b/core.go
@@ -272,6 +272,7 @@ func tracingWrapper(h http.Handler) http.Handler {
 						rec.status = http.StatusInternalServerError
 					}
 					serverSpan.RecordError(fmt.Errorf("panic: %v", recovered))
+					serverSpan.SetStatus(codes.Error, "panic")
 					endSpan(serverSpan, rec)
 					panic(recovered)
 				}

--- a/core_coverage_test.go
+++ b/core_coverage_test.go
@@ -360,6 +360,9 @@ func TestTracingWrapperSpanAttributes(t *testing.T) {
 	if v := attrs["http.response.status_code"]; v != int64(200) {
 		t.Fatalf("expected http.response.status_code=200, got %v", v)
 	}
+	if v := attrs["url.scheme"]; v != "http" {
+		t.Fatalf("expected url.scheme=http, got %v", v)
+	}
 }
 
 func TestTracingWrapperSpanErrorStatus(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix `spanRouteMiddleware` to use `runtime.HTTPPattern` (Pattern struct set by `handleHandler`) instead of `runtime.HTTPPathPattern` (string set later inside `AnnotateContext`). This was causing route patterns to never appear in span names.
- Add tests with in-memory OTel exporter verifying span name, all semconv attributes, and end-to-end grpc-gateway route pattern extraction

## Test plan
- [x] `make test` passes with `-race`
- [x] `TestTracingWrapperSpanAttributes` verifies all span attributes
- [x] `TestTracingWrapperGatewaySpanName` verifies span renamed to `GET /api/v1/rules/{rule_id=*}` with `http.route` attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HTTP tracing: more accurate scheme detection (including forwarded proto), server address recorded only when present, route-pattern-based span naming, and automatic capture of panics as 500 errors in spans.

* **Tests**
  * Added end-to-end tracing tests verifying span names, HTTP semantic attributes, error status for panics, and route pattern attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->