### PR TITLE
feat: switch SetupLogger to slog-native log.SetDefault

### DIFF
--- a/core_coverage_test.go
+++ b/core_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/go-coldbrew/core/config"
+	"github.com/go-coldbrew/log"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -1306,9 +1308,19 @@ func TestVTProtoCodec_Name(t *testing.T) {
 // --- Group 8: Standalone Initializer Tests ---
 
 func TestSetupLogger_ValidLevel(t *testing.T) {
+	prevSlog := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prevSlog) })
+
 	err := SetupLogger("info", false)
 	if err != nil {
 		t.Fatalf("SetupLogger with valid level failed: %v", err)
+	}
+
+	// Verify slog.Default is wired through ColdBrew's Handler so native
+	// slog calls get context fields injected.
+	handler := slog.Default().Handler()
+	if _, ok := handler.(*log.Handler); !ok {
+		t.Errorf("expected slog.Default handler to be *log.Handler, got %T", handler)
 	}
 }
 

--- a/core_coverage_test.go
+++ b/core_coverage_test.go
@@ -1309,7 +1309,11 @@ func TestVTProtoCodec_Name(t *testing.T) {
 
 func TestSetupLogger_ValidLevel(t *testing.T) {
 	prevSlog := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(prevSlog) })
+	prevHandler := log.GetHandler()
+	t.Cleanup(func() {
+		slog.SetDefault(prevSlog)
+		log.SetDefault(prevHandler)
+	})
 
 	err := SetupLogger("info", false)
 	if err != nil {

--- a/core_coverage_test.go
+++ b/core_coverage_test.go
@@ -1328,6 +1328,31 @@ func TestSetupLogger_ValidLevel(t *testing.T) {
 	}
 }
 
+func TestSetupLogger_RespectsExistingHandler(t *testing.T) {
+	prevSlog := slog.Default()
+	prevHandler := log.GetHandler()
+	t.Cleanup(func() {
+		slog.SetDefault(prevSlog)
+		log.SetDefault(prevHandler)
+	})
+
+	// User sets a custom handler before core runs.
+	customInner := slog.NewJSONHandler(io.Discard, nil)
+	customHandler := log.NewHandlerWithInner(customInner)
+	log.SetDefault(customHandler)
+
+	// SetupLogger should respect it and only update the level.
+	err := SetupLogger("debug", true)
+	if err != nil {
+		t.Fatalf("SetupLogger failed: %v", err)
+	}
+
+	// The handler should still be our custom one, not a new default.
+	if log.GetHandler() != customHandler {
+		t.Error("expected SetupLogger to preserve the custom handler")
+	}
+}
+
 func TestSetupLogger_InvalidLevel(t *testing.T) {
 	err := SetupLogger("notavalidlevel", false)
 	if err == nil {

--- a/core_coverage_test.go
+++ b/core_coverage_test.go
@@ -1311,8 +1311,8 @@ func TestSetupLogger_ValidLevel(t *testing.T) {
 	prevSlog := slog.Default()
 	prevHandler := log.GetHandler()
 	t.Cleanup(func() {
-		slog.SetDefault(prevSlog)
 		log.SetDefault(prevHandler)
+		slog.SetDefault(prevSlog)
 	})
 
 	err := SetupLogger("info", false)
@@ -1332,8 +1332,8 @@ func TestSetupLogger_RespectsExistingHandler(t *testing.T) {
 	prevSlog := slog.Default()
 	prevHandler := log.GetHandler()
 	t.Cleanup(func() {
-		slog.SetDefault(prevSlog)
 		log.SetDefault(prevHandler)
+		slog.SetDefault(prevSlog)
 	})
 
 	// User sets a custom handler before core runs.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-coldbrew/errors v0.2.14
 	github.com/go-coldbrew/hystrixprometheus v0.1.2
 	github.com/go-coldbrew/interceptors v0.1.24
-	github.com/go-coldbrew/log v0.4.0
+	github.com/go-coldbrew/log v0.4.1
 	github.com/go-coldbrew/options v0.3.0
 	github.com/go-coldbrew/tracing v0.2.2
 	github.com/golang/protobuf v1.5.4

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-coldbrew/errors v0.2.14
 	github.com/go-coldbrew/hystrixprometheus v0.1.2
 	github.com/go-coldbrew/interceptors v0.1.24
-	github.com/go-coldbrew/log v0.3.2
+	github.com/go-coldbrew/log v0.4.0
 	github.com/go-coldbrew/options v0.3.0
 	github.com/go-coldbrew/tracing v0.2.2
 	github.com/golang/protobuf v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/go-coldbrew/hystrixprometheus v0.1.2 h1:WSt4FtYr8xNDKgdGWYpMfXGFIK7zd
 github.com/go-coldbrew/hystrixprometheus v0.1.2/go.mod h1:OrNRHHxZagpmQXNp//oHKOemGSU0ScOqEcJgeKbJ+wg=
 github.com/go-coldbrew/interceptors v0.1.24 h1:z24O4TRxT/+fHTJIILml9ulmK2cYGKKCENpxxL8pGaA=
 github.com/go-coldbrew/interceptors v0.1.24/go.mod h1:YkAmxYZ7R3Sjif0WpzhuhGjv2j67CwUoqnq9K8XgpBY=
-github.com/go-coldbrew/log v0.4.0 h1:Oe243xMvFGgNtS/LpNAA3BVR/kSRqFOyWdVOVdyTo2I=
-github.com/go-coldbrew/log v0.4.0/go.mod h1:HqGpOhI4nCnl8OjM3awye4joR7m2tducjQBltMb0QiY=
+github.com/go-coldbrew/log v0.4.1 h1:ZvTU7YXBFfe9QD9diY8lVD/WhkvpyoyixpFJAMq4+Ps=
+github.com/go-coldbrew/log v0.4.1/go.mod h1:HqGpOhI4nCnl8OjM3awye4joR7m2tducjQBltMb0QiY=
 github.com/go-coldbrew/options v0.3.0 h1:JwyVntb9bzBeFdaHFK6yGVVz30G3aVlqJJ6uVyYQfCc=
 github.com/go-coldbrew/options v0.3.0/go.mod h1:8JlmgVJXFoY1KiDLsyMmR//q1U1aBItCexvTrVT2Y60=
 github.com/go-coldbrew/tracing v0.2.2 h1:pvRMSwla5txZgtQOi18OqsuJhtsqPbfeC1arH9tJMys=

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/go-coldbrew/hystrixprometheus v0.1.2 h1:WSt4FtYr8xNDKgdGWYpMfXGFIK7zd
 github.com/go-coldbrew/hystrixprometheus v0.1.2/go.mod h1:OrNRHHxZagpmQXNp//oHKOemGSU0ScOqEcJgeKbJ+wg=
 github.com/go-coldbrew/interceptors v0.1.24 h1:z24O4TRxT/+fHTJIILml9ulmK2cYGKKCENpxxL8pGaA=
 github.com/go-coldbrew/interceptors v0.1.24/go.mod h1:YkAmxYZ7R3Sjif0WpzhuhGjv2j67CwUoqnq9K8XgpBY=
-github.com/go-coldbrew/log v0.3.2 h1:CoHa0PGX7a7o/Cv/ke7PdQfq4LKtbPVypUf3uXcRLMs=
-github.com/go-coldbrew/log v0.3.2/go.mod h1:tumRNCmLWRep5wnhS/vzDQ7UMinF6OZ7WW8K/qlXAzc=
+github.com/go-coldbrew/log v0.4.0 h1:Oe243xMvFGgNtS/LpNAA3BVR/kSRqFOyWdVOVdyTo2I=
+github.com/go-coldbrew/log v0.4.0/go.mod h1:HqGpOhI4nCnl8OjM3awye4joR7m2tducjQBltMb0QiY=
 github.com/go-coldbrew/options v0.3.0 h1:JwyVntb9bzBeFdaHFK6yGVVz30G3aVlqJJ6uVyYQfCc=
 github.com/go-coldbrew/options v0.3.0/go.mod h1:8JlmgVJXFoY1KiDLsyMmR//q1U1aBItCexvTrVT2Y60=
 github.com/go-coldbrew/tracing v0.2.2 h1:pvRMSwla5txZgtQOi18OqsuJhtsqPbfeC1arH9tJMys=
@@ -219,10 +219,6 @@ github.com/go-git/go-git/v5 v5.17.1 h1:WnljyxIzSj9BRRUlnmAU35ohDsjRK0EKmL0evDqi5
 github.com/go-git/go-git/v5 v5.17.1/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
-github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
-github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
-github.com/go-logfmt/logfmt v0.6.1 h1:4hvbpePJKnIzH1B+8OR/JPbTx37NktoI9LE2QZBBkvE=
-github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/z6CO0XAk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/initializers.go
+++ b/initializers.go
@@ -18,7 +18,6 @@ import (
 	"github.com/go-coldbrew/interceptors"
 	"github.com/go-coldbrew/log"
 	"github.com/go-coldbrew/log/loggers"
-	cbslog "github.com/go-coldbrew/log/loggers/slog"
 	nrutil "github.com/go-coldbrew/tracing/newrelic"
 	protov1 "github.com/golang/protobuf/proto" //nolint:staticcheck
 	newrelic "github.com/newrelic/go-agent/v3/newrelic"
@@ -67,19 +66,18 @@ func SetupNewRelic(serviceName, apiKey string, tracing bool) error {
 	return nil
 }
 
-// SetupLogger sets up the logger
-// It uses the coldbrew logger to log messages to stdout
+// SetupLogger sets up the logger using ColdBrew's slog-native Handler.
+// It calls log.SetDefault which also wires slog.SetDefault, so native
+// slog.LogAttrs calls automatically get ColdBrew context fields.
 // logLevel is the log level to set for the logger
 // jsonlogs is a boolean to enable or disable json logs
 func SetupLogger(logLevel string, jsonlogs bool) error {
-	log.SetLogger(log.NewLogger(cbslog.NewLogger(loggers.WithJSONLogs(jsonlogs))))
-
 	ll, err := loggers.ParseLevel(logLevel)
 	if err != nil {
 		log.Error(context.Background(), "err", "could not set log level", "level", logLevel)
 		return err
 	}
-	log.SetLevel(ll)
+	log.SetDefault(log.NewHandler(loggers.WithJSONLogs(jsonlogs), loggers.WithLevel(ll)))
 	return nil
 }
 

--- a/initializers.go
+++ b/initializers.go
@@ -74,7 +74,7 @@ func SetupNewRelic(serviceName, apiKey string, tracing bool) error {
 func SetupLogger(logLevel string, jsonlogs bool) error {
 	ll, err := loggers.ParseLevel(logLevel)
 	if err != nil {
-		log.Error(context.Background(), "err", "could not set log level", "level", logLevel)
+		log.Error(context.Background(), "msg", "could not set log level", "level", logLevel, "err", err)
 		return err
 	}
 	log.SetDefault(log.NewHandler(loggers.WithJSONLogs(jsonlogs), loggers.WithLevel(ll)))

--- a/initializers.go
+++ b/initializers.go
@@ -77,6 +77,11 @@ func SetupLogger(logLevel string, jsonlogs bool) error {
 		log.Error(context.Background(), "msg", "could not set log level", "level", logLevel, "err", err)
 		return err
 	}
+	if log.DefaultIsSet() {
+		// User already configured a custom handler via log.SetDefault — respect it.
+		log.SetLevel(ll)
+		return nil
+	}
 	log.SetDefault(log.NewHandler(loggers.WithJSONLogs(jsonlogs), loggers.WithLevel(ll)))
 	return nil
 }


### PR DESCRIPTION
## Summary

- Replace `log.SetLogger(log.NewLogger(cbslog.NewLogger(...)))` with `log.SetDefault(log.NewHandler(...))`
- `log.SetDefault` also calls `slog.SetDefault`, enabling native `slog.LogAttrs` calls to automatically get ColdBrew context fields (trace ID, gRPC method, etc.)
- Remove `cbslog` (`loggers/slog`) import — backend logic is now in `log.Handler`
- Bump `go-coldbrew/log` to v0.4.0

## Why

Without this change, `core.New()` sets up logging via the deprecated `BaseLogger` path, which never calls `slog.SetDefault`. This means native `slog.LogAttrs` calls in service code don't get ColdBrew context fields — breaking the cookiecutter template's switch to `slog.LogAttrs` (go-coldbrew/cookiecutter-coldbrew#34).

## Test plan

- [x] Code change is minimal (5 lines changed in SetupLogger)
- [ ] `make test` — CI will verify
- [ ] `make lint` — CI will verify

Ref: go-coldbrew/log#27, go-coldbrew/cookiecutter-coldbrew#34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the logging dependency and updated logger behavior so configuration now preserves any existing logger and applies levels safely, while still initializing a default logger when none is present.
* **Tests**
  * Improved logger-related tests to verify global logging integration and to ensure configuration is isolated and restored during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->