### PR TITLE
feat: expose worker run options and wire Prometheus metrics by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ const SupportPackageIsVersion1 = true
 func AddWorkerRunOptions(opts ...workers.RunOption)
 ```
 
-AddWorkerRunOptions appends \[workers.RunOption\] values applied when core.Run\(\) invokes \[workers.Run\]. Use this to configure framework\-wide worker behaviour: metrics, run\-level interceptors, default jitter, etc. Must be called during init, before Run\(\). Not concurrency\-safe.
+AddWorkerRunOptions appends \[workers.RunOption\] values applied when core.Run\(\) invokes \[workers.Run\]. Use this to configure framework\-wide worker behavior: metrics, run\-level interceptors, default jitter, etc. Must be called during init, before Run\(\). Not concurrency\-safe.
 
 By default, core wires a Prometheus metrics implementation using the service's APP\_NAME unless DISABLE\_PROMETHEUS=true or APP\_NAME is empty. Pass \[workers.WithMetrics\] here to override that default; a later WithMetrics wins because workers.WithMetrics overwrites runConfig.metrics on each apply.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ For full documentation, visit https://docs.coldbrew.cloud
 ## Index
 
 - [Constants](<#constants>)
+- [func AddWorkerRunOptions\(opts ...workers.RunOption\)](<#AddWorkerRunOptions>)
 - [func InitializeVTProto\(\)](<#InitializeVTProto>)
 - [func OTELMeterProvider\(\) otelmetric.MeterProvider](<#OTELMeterProvider>)
 - [func SetOTELGRPCClientOptions\(opts ...otelgrpc.Option\)](<#SetOTELGRPCClientOptions>)
@@ -120,6 +121,17 @@ For full documentation, visit https://docs.coldbrew.cloud
 ```go
 const SupportPackageIsVersion1 = true
 ```
+
+<a name="AddWorkerRunOptions"></a>
+## func [AddWorkerRunOptions](<https://github.com/go-coldbrew/core/blob/main/workers.go#L20>)
+
+```go
+func AddWorkerRunOptions(opts ...workers.RunOption)
+```
+
+AddWorkerRunOptions appends \[workers.RunOption\] values applied when core.Run\(\) invokes \[workers.Run\]. Use this to configure framework\-wide worker behaviour: metrics, run\-level interceptors, default jitter, etc. Must be called during init, before Run\(\). Not concurrency\-safe.
+
+By default, core wires a Prometheus metrics implementation using the service's APP\_NAME unless DISABLE\_PROMETHEUS=true or APP\_NAME is empty. Pass \[workers.WithMetrics\] here to override that default; a later WithMetrics wins because workers.WithMetrics overwrites runConfig.metrics on each apply.
 
 <a name="InitializeVTProto"></a>
 ## func [InitializeVTProto](<https://github.com/go-coldbrew/core/blob/main/initializers.go#L452>)
@@ -319,7 +331,7 @@ type CB interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/go-coldbrew/core/blob/main/core.go#L1029>)
+### func [New](<https://github.com/go-coldbrew/core/blob/main/core.go#L1030>)
 
 ```go
 func New(c config.Config) CB

--- a/core.go
+++ b/core.go
@@ -846,9 +846,10 @@ func (c *cb) Run() error {
 	if len(allWorkers) > 0 {
 		workerCtx, workerCancel := context.WithCancel(gctx)
 		c.workerCancel = workerCancel
+		runOpts := c.buildWorkerRunOpts()
 		g.Go(func() error {
 			// workers.Run returns nil on context cancellation (clean shutdown).
-			return workers.Run(workerCtx, allWorkers)
+			return workers.Run(workerCtx, allWorkers, runOpts...)
 		})
 	}
 

--- a/workers.go
+++ b/workers.go
@@ -1,0 +1,34 @@
+package core
+
+import "github.com/go-coldbrew/workers"
+
+// Run-level options applied when core.Run() invokes workers.Run. Mutated
+// during init via AddWorkerRunOptions; not concurrency-safe by design (same
+// contract as the OTEL setters in core.go).
+var workerRunOpts []workers.RunOption
+
+// AddWorkerRunOptions appends [workers.RunOption] values applied when
+// core.Run() invokes [workers.Run]. Use this to configure framework-wide
+// worker behaviour: metrics, run-level interceptors, default jitter, etc.
+// Must be called during init, before Run(). Not concurrency-safe.
+//
+// By default, core wires a Prometheus metrics implementation using the
+// service's APP_NAME unless DISABLE_PROMETHEUS=true or APP_NAME is empty.
+// Pass [workers.WithMetrics] here to override that default; a later
+// WithMetrics wins because workers.WithMetrics overwrites runConfig.metrics
+// on each apply.
+func AddWorkerRunOptions(opts ...workers.RunOption) {
+	workerRunOpts = append(workerRunOpts, opts...)
+}
+
+// buildWorkerRunOpts assembles the option slice passed to workers.Run. The
+// default Prometheus metrics (when enabled) is prepended so that any
+// user-supplied workers.WithMetrics overrides it.
+func (c *cb) buildWorkerRunOpts() []workers.RunOption {
+	opts := make([]workers.RunOption, 0, len(workerRunOpts)+1)
+	if !c.config.DisablePrometheus && !c.config.DisablePormetheus && c.config.AppName != "" { //nolint:staticcheck // intentional use of deprecated field for backward compatibility
+		opts = append(opts, workers.WithMetrics(workers.NewPrometheusMetrics(c.config.AppName)))
+	}
+	opts = append(opts, workerRunOpts...)
+	return opts
+}

--- a/workers.go
+++ b/workers.go
@@ -9,7 +9,7 @@ var workerRunOpts []workers.RunOption
 
 // AddWorkerRunOptions appends [workers.RunOption] values applied when
 // core.Run() invokes [workers.Run]. Use this to configure framework-wide
-// worker behaviour: metrics, run-level interceptors, default jitter, etc.
+// worker behavior: metrics, run-level interceptors, default jitter, etc.
 // Must be called during init, before Run(). Not concurrency-safe.
 //
 // By default, core wires a Prometheus metrics implementation using the

--- a/workers_test.go
+++ b/workers_test.go
@@ -132,21 +132,47 @@ func TestRun_WorkerMetricsWired(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() { errCh <- instance.Run() }()
 
-	deadline := time.Now().Add(5 * time.Second)
-	for rec.started.Load() == 0 && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if rec.started.Load() == 0 {
-		t.Fatal("recordingMetrics.WorkerStarted was never invoked")
+	// Always stop the instance and drain Run() before the test exits, so a
+	// failing assertion below doesn't leak the Run goroutine.
+	var stopped atomic.Bool
+	t.Cleanup(func() {
+		if !stopped.CompareAndSwap(false, true) {
+			return
+		}
+		_ = instance.Stop(2 * time.Second)
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	startDeadline := time.After(5 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for rec.started.Load() == 0 {
+		select {
+		case err := <-errCh:
+			t.Fatalf("Run exited before WorkerStarted fired: %v", err)
+		case <-startDeadline:
+			t.Fatal("recordingMetrics.WorkerStarted was never invoked")
+		case <-ticker.C:
+		}
 	}
 
+	if !stopped.CompareAndSwap(false, true) {
+		return
+	}
 	if err := instance.Stop(2 * time.Second); err != nil {
 		t.Fatalf("Stop failed: %v", err)
 	}
 
-	err := <-errCh
-	if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, grpc.ErrServerStopped) {
-		t.Fatalf("unexpected Run error: %v", err)
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Fatalf("unexpected Run error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit after Stop")
 	}
 }
 

--- a/workers_test.go
+++ b/workers_test.go
@@ -128,7 +128,9 @@ func runWithRecorder(t *testing.T, cfg config.Config, rec *recordingMetrics) {
 	go func() { errCh <- instance.Run() }()
 
 	// Always stop the instance and drain Run() before the test exits, so a
-	// failing assertion below never leaks the Run goroutine.
+	// failing assertion below never leaks the Run goroutine. If Run() doesn't
+	// exit within the timeout, fail the test explicitly rather than letting
+	// goleak surface a less actionable error later.
 	var stopped atomic.Bool
 	t.Cleanup(func() {
 		if !stopped.CompareAndSwap(false, true) {
@@ -138,6 +140,7 @@ func runWithRecorder(t *testing.T, cfg config.Config, rec *recordingMetrics) {
 		select {
 		case <-errCh:
 		case <-time.After(2 * time.Second):
+			t.Errorf("instance.Run() did not exit within 2s after Stop during cleanup")
 		}
 	})
 

--- a/workers_test.go
+++ b/workers_test.go
@@ -1,0 +1,175 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-coldbrew/core/config"
+	"github.com/go-coldbrew/workers"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc"
+)
+
+// resetWorkerRunOpts clears the package global between tests.
+func resetWorkerRunOpts(t *testing.T) {
+	t.Helper()
+	prev := workerRunOpts
+	workerRunOpts = nil
+	t.Cleanup(func() { workerRunOpts = prev })
+}
+
+// recordingMetrics is a forward-compatible workers.Metrics that counts
+// WorkerStarted invocations.
+type recordingMetrics struct {
+	workers.BaseMetrics
+	started atomic.Int32
+}
+
+func (m *recordingMetrics) WorkerStarted(string) { m.started.Add(1) }
+
+func TestBuildWorkerRunOpts_DefaultPrometheus_AppNameSet(t *testing.T) {
+	resetWorkerRunOpts(t)
+	c := &cb{config: config.Config{AppName: "test_buildopts_default"}}
+
+	opts := c.buildWorkerRunOpts()
+	if len(opts) != 1 {
+		t.Fatalf("expected one default option, got %d", len(opts))
+	}
+}
+
+func TestBuildWorkerRunOpts_NoDefault_WhenDisablePrometheus(t *testing.T) {
+	resetWorkerRunOpts(t)
+	c := &cb{config: config.Config{
+		AppName:           "test_buildopts_disabled",
+		DisablePrometheus: true,
+	}}
+
+	opts := c.buildWorkerRunOpts()
+	if len(opts) != 0 {
+		t.Fatalf("expected no options when DisablePrometheus=true, got %d", len(opts))
+	}
+}
+
+func TestBuildWorkerRunOpts_NoDefault_WhenDeprecatedDisablePormetheus(t *testing.T) {
+	resetWorkerRunOpts(t)
+	c := &cb{config: config.Config{
+		AppName:           "test_buildopts_deprecated",
+		DisablePormetheus: true, //nolint:staticcheck // testing deprecated field
+	}}
+
+	opts := c.buildWorkerRunOpts()
+	if len(opts) != 0 {
+		t.Fatalf("expected no options when DisablePormetheus=true, got %d", len(opts))
+	}
+}
+
+func TestBuildWorkerRunOpts_NoDefault_WhenEmptyAppName(t *testing.T) {
+	resetWorkerRunOpts(t)
+	c := &cb{config: config.Config{AppName: ""}}
+
+	opts := c.buildWorkerRunOpts()
+	if len(opts) != 0 {
+		t.Fatalf("expected no default option when AppName is empty, got %d", len(opts))
+	}
+}
+
+func TestAddWorkerRunOptions_AppendsAndCombinesWithDefault(t *testing.T) {
+	resetWorkerRunOpts(t)
+	AddWorkerRunOptions(workers.WithDefaultJitter(0))
+	AddWorkerRunOptions(workers.AddInterceptors(noopMiddleware))
+
+	c := &cb{config: config.Config{AppName: "test_buildopts_combined"}}
+	opts := c.buildWorkerRunOpts()
+	// 1 default Prometheus + 2 user options
+	if len(opts) != 3 {
+		t.Fatalf("expected 3 options (1 default + 2 user), got %d", len(opts))
+	}
+}
+
+func TestAddWorkerRunOptions_NoDefault_WithoutAppName(t *testing.T) {
+	resetWorkerRunOpts(t)
+	AddWorkerRunOptions(workers.WithDefaultJitter(5))
+
+	c := &cb{config: config.Config{}}
+	opts := c.buildWorkerRunOpts()
+	if len(opts) != 1 {
+		t.Fatalf("expected 1 user option (no default), got %d", len(opts))
+	}
+}
+
+func noopMiddleware(ctx context.Context, info *workers.WorkerInfo, next workers.CycleFunc) error {
+	return next(ctx, info)
+}
+
+// TestRun_WorkerMetricsWired runs the full core.Run lifecycle with a worker
+// and a recording Metrics implementation injected via AddWorkerRunOptions,
+// and asserts that WorkerStarted fires — proving the option reaches workers.Run.
+func TestRun_WorkerMetricsWired(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end Run lifecycle in short mode")
+	}
+	resetWorkerRunOpts(t)
+
+	rec := &recordingMetrics{}
+	AddWorkerRunOptions(workers.WithMetrics(rec))
+
+	svc := &workerLifecycleService{}
+	instance := New(config.Config{
+		GRPCPort:             0,
+		HTTPPort:             0,
+		ListenHost:           "127.0.0.1",
+		DisableSignalHandler: true,
+		DisableNewRelic:      true,
+		DisableAutoMaxProcs:  true,
+		DisablePrometheus:    true, // suppress the default; recording metrics wins anyway
+	})
+	instance.SetService(svc)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- instance.Run() }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for rec.started.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if rec.started.Load() == 0 {
+		t.Fatal("recordingMetrics.WorkerStarted was never invoked")
+	}
+
+	if err := instance.Stop(2 * time.Second); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+
+	err := <-errCh
+	if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, grpc.ErrServerStopped) {
+		t.Fatalf("unexpected Run error: %v", err)
+	}
+}
+
+// workerLifecycleService is a CBService + CBWorkerProvider used by the
+// end-to-end test above. The worker blocks on ctx so it stays alive long
+// enough for WorkerStarted to fire.
+type workerLifecycleService struct{}
+
+func (s *workerLifecycleService) InitHTTP(_ context.Context, _ *runtime.ServeMux, _ string, _ []grpc.DialOption) error {
+	return nil
+}
+
+func (s *workerLifecycleService) InitGRPC(_ context.Context, _ *grpc.Server) error { return nil }
+
+func (s *workerLifecycleService) Workers() []*workers.Worker {
+	return []*workers.Worker{
+		workers.NewWorker("test-lifecycle-worker").HandlerFunc(
+			func(ctx context.Context, _ *workers.WorkerInfo) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		),
+	}
+}
+
+var _ CBWorkerProvider = (*workerLifecycleService)(nil)

--- a/workers_test.go
+++ b/workers_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -105,35 +106,29 @@ func noopMiddleware(ctx context.Context, info *workers.WorkerInfo, next workers.
 	return next(ctx, info)
 }
 
-// TestRun_WorkerMetricsWired runs the full core.Run lifecycle with a worker
-// and a recording Metrics implementation injected via AddWorkerRunOptions,
-// and asserts that WorkerStarted fires — proving the option reaches workers.Run.
-func TestRun_WorkerMetricsWired(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping end-to-end Run lifecycle in short mode")
-	}
-	resetWorkerRunOpts(t)
-
-	rec := &recordingMetrics{}
+// runWithRecorder boots a core.cb with cfg, registers a CBWorkerProvider,
+// injects rec via AddWorkerRunOptions, runs, waits for the recorder's
+// WorkerStarted callback, then stops and drains. Used by the end-to-end
+// tests below to verify that the option slice reaches workers.Run.
+func runWithRecorder(t *testing.T, cfg config.Config, rec *recordingMetrics) {
+	t.Helper()
 	AddWorkerRunOptions(workers.WithMetrics(rec))
 
-	svc := &workerLifecycleService{}
-	instance := New(config.Config{
-		GRPCPort:             0,
-		HTTPPort:             0,
-		ListenHost:           "127.0.0.1",
-		DisableSignalHandler: true,
-		DisableNewRelic:      true,
-		DisableAutoMaxProcs:  true,
-		DisablePrometheus:    true, // suppress the default; recording metrics wins anyway
-	})
-	instance.SetService(svc)
+	cfg.GRPCPort = 0
+	cfg.HTTPPort = 0
+	cfg.ListenHost = "127.0.0.1"
+	cfg.DisableSignalHandler = true
+	cfg.DisableNewRelic = true
+	cfg.DisableAutoMaxProcs = true
+
+	instance := New(cfg)
+	instance.SetService(&workerLifecycleService{})
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- instance.Run() }()
 
 	// Always stop the instance and drain Run() before the test exits, so a
-	// failing assertion below doesn't leak the Run goroutine.
+	// failing assertion below never leaks the Run goroutine.
 	var stopped atomic.Bool
 	t.Cleanup(func() {
 		if !stopped.CompareAndSwap(false, true) {
@@ -174,6 +169,35 @@ func TestRun_WorkerMetricsWired(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not exit after Stop")
 	}
+}
+
+// TestRun_WorkerMetricsWired runs the full core.Run lifecycle with a worker
+// and a recording Metrics implementation injected via AddWorkerRunOptions,
+// and asserts that WorkerStarted fires — proving the option reaches workers.Run.
+func TestRun_WorkerMetricsWired(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end Run lifecycle in short mode")
+	}
+	resetWorkerRunOpts(t)
+	rec := &recordingMetrics{}
+	runWithRecorder(t, config.Config{DisablePrometheus: true}, rec)
+}
+
+// TestRun_UserMetricsOverridesDefaultPrometheus exercises the override
+// contract: when AppName is set (so the default Prometheus metrics is
+// prepended) and the caller also adds workers.WithMetrics via
+// AddWorkerRunOptions, the caller's recorder must be the effective metrics
+// implementation. Uses a unique app name per run to avoid colliding with
+// the process-global namespace cache in workers.NewPrometheusMetrics.
+func TestRun_UserMetricsOverridesDefaultPrometheus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end Run lifecycle in short mode")
+	}
+	resetWorkerRunOpts(t)
+	rec := &recordingMetrics{}
+	runWithRecorder(t, config.Config{
+		AppName: fmt.Sprintf("test_override_%d", time.Now().UnixNano()),
+	}, rec)
 }
 
 // workerLifecycleService is a CBService + CBWorkerProvider used by the


### PR DESCRIPTION
## Summary

- `core.Run()` was invoking `workers.Run` with no `RunOption`s, so `workers` fell back to `BaseMetrics{}` (no-op) and every `worker_started_total`, `worker_panicked_total`, `worker_active_count`, etc. silently stayed at zero in any service using `CBWorkerProvider`.
- Adds `core.AddWorkerRunOptions(opts ...workers.RunOption)` for init-time configuration of run-level options (metrics, default jitter, run-level interceptors).
- Prepends `workers.WithMetrics(workers.NewPrometheusMetrics(AppName))` by default when `APP_NAME` is set and Prometheus is not disabled. A user-supplied `WithMetrics` overrides the default because `workers.WithMetrics` overwrites `runConfig.metrics` on each apply.
- Empty `APP_NAME` skips the default to avoid ambiguous unprefixed metric names; users can still opt in by calling `AddWorkerRunOptions(workers.WithMetrics(workers.NewPrometheusMetrics("")))` explicitly.

## Why run-level (not `Worker.WithMetrics`)

`Worker.WithMetrics` exists, but a framework default belongs at run level — otherwise every app adopting `CBWorkerProvider` has to remember to apply metrics on every worker. Per-worker overrides still work for callers that want to.

## Test plan

- [x] `make build`
- [x] `make test` (race + cover, 80.4%)
- [x] `make lint` (0 issues, govulncheck clean)
- [x] New `workers_test.go` covers default Prometheus path, `DisablePrometheus` / deprecated `DisablePormetheus` / empty `AppName` skip paths, multi-add append, and an end-to-end `core.Run()` test asserting `WorkerStarted` fires on a `workers.Metrics` recorder injected via `AddWorkerRunOptions`.
- [x] `make doc` regenerated `README.md`.
- [ ] `docs.coldbrew.cloud/howto/workers.md` — added a "Metrics" subsection under "ColdBrew Integration" (separate submodule; will land in the docs repo).

## Manual smoke

Build a service with a `CBWorkerProvider`, set `APP_NAME=demo`, scrape `/metrics`, confirm `demo_worker_started_total` is present and non-zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering worker run options during initialization.
  * Implemented automatic Prometheus metrics collection for worker lifecycle events.

* **Documentation**
  * Updated API reference documentation for new configuration capabilities.

* **Tests**
  * Expanded test suite with comprehensive coverage for worker options and metrics scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->