### PR TITLE
docs(config): document dual-loader support (envconfig + env-tag)

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -67,9 +67,14 @@ import "github.com/go-coldbrew/core/config"
 
 
 <a name="Config"></a>
-## type [Config](<https://github.com/go-coldbrew/core/blob/main/config/config.go#L13-L211>)
+## type [Config](<https://github.com/go-coldbrew/core/blob/main/config/config.go#L21-L219>)
 
-Config is the configuration for the Coldbrew server It is populated from environment variables and has sensible defaults for all fields so that you can just use it as is without any configuration The following environment variables are supported and can be used to override the defaults for the fields
+Config is the configuration for the Coldbrew server. It is populated from environment variables and has sensible defaults for all fields so that you can just use it as is without any configuration. The following environment variables are supported and can be used to override the defaults for the fields.
+
+Each field carries both \`envconfig:"…"\` and \`env:"…"\` struct tags, so the struct can be populated by either family of loaders:
+
+- github.com/kelseyhightower/envconfig \(the cookiecutter default\)
+- any \`env:\`\-tag loader, e.g. github.com/caarlos0/env, github.com/sethvargo/go\-envconfig, or github.com/ilyakaznacheev/cleanenv
 
 ```go
 type Config struct {
@@ -269,7 +274,7 @@ type Config struct {
 ```
 
 <a name="Config.Validate"></a>
-### func \(Config\) [Validate](<https://github.com/go-coldbrew/core/blob/main/config/config.go#L216>)
+### func \(Config\) [Validate](<https://github.com/go-coldbrew/core/blob/main/config/config.go#L224>)
 
 ```go
 func (c Config) Validate() []string
@@ -278,7 +283,7 @@ func (c Config) Validate() []string
 Validate checks the configuration for common misconfigurations and returns a list of warning messages. It does not return an error to avoid breaking existing services — warnings are meant to be logged at startup.
 
 <a name="Config.ValidateStrict"></a>
-### func \(Config\) [ValidateStrict](<https://github.com/go-coldbrew/core/blob/main/config/config.go#L307>)
+### func \(Config\) [ValidateStrict](<https://github.com/go-coldbrew/core/blob/main/config/config.go#L315>)
 
 ```go
 func (c Config) ValidateStrict() []error

--- a/config/config.go
+++ b/config/config.go
@@ -7,9 +7,17 @@ import (
 	"strings"
 )
 
-// Config is the configuration for the Coldbrew server
-// It is populated from environment variables and has sensible defaults for all fields so that you can just use it as is without any configuration
-// The following environment variables are supported and can be used to override the defaults for the fields
+// Config is the configuration for the Coldbrew server.
+// It is populated from environment variables and has sensible defaults for all
+// fields so that you can just use it as is without any configuration.
+// The following environment variables are supported and can be used to override
+// the defaults for the fields.
+//
+// Each field carries both `envconfig:"…"` and `env:"…"` struct tags, so the
+// struct can be populated by either family of loaders:
+//   - github.com/kelseyhightower/envconfig (the cookiecutter default)
+//   - any `env:`-tag loader, e.g. github.com/caarlos0/env,
+//     github.com/sethvargo/go-envconfig, or github.com/ilyakaznacheev/cleanenv
 type Config struct {
 	// Host to listen on
 	ListenHost string `envconfig:"LISTEN_HOST" env:"LISTEN_HOST" default:"0.0.0.0"`


### PR DESCRIPTION
## Summary

- The `Config` struct already carries both `envconfig:"…"` and `env:"…"` struct tags on every field, so it can be populated by either family of loaders. The type doc comment only mentioned envconfig, hiding this from `env:`-tag users.
- Extended the `Config` doc comment to document dual-loader support and list the common compatible loaders (`kelseyhightower/envconfig`, `caarlos0/env`, `sethvargo/go-envconfig`, `ilyakaznacheev/cleanenv`).
- Regenerated `config/README.md` via `make doc`.

No code or behavior changes — comment-only.

## Test plan

- [x] `make build` clean
- [x] `make lint` clean (0 issues, govulncheck clean)
- [x] `config/README.md` regenerated via `make doc`; diff limited to the Config type paragraph and three line-number anchors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced configuration documentation with clearer guidance on environment variable setup and supported configuration loaders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->